### PR TITLE
Adding k8s Pods role

### DIFF
--- a/roles/k8s_pods/tasks/main.yml
+++ b/roles/k8s_pods/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+  - name: check node
+    command: "/usr/local/bin/kubectl --kubeconfig={{ kube_config }} cluster-info"
+    register: cluster_status
+    ignore_errors: true
+
+  - block:
+    
+    - name: Get pod info
+      k8s_facts:
+        kind: Pod
+        kubeconfig: "{{ kube_config }}"
+      register: pod_list
+
+    - name: Set info as facts
+      set_fact:
+        stockpile_k8s_pods: "{{ pod_list.resources }}"
+
+    when: cluster_status is succeeded

--- a/stockpile.yml
+++ b/stockpile.yml
@@ -34,6 +34,7 @@
     #- { role: k8s_cluster_contexts, tags: k8s_cluster_contexts }
     - { role: k8s_namespaces, tags: k8s_namespaces }
     - { role: k8s_nodes, tags: k8s_nodes }
+    - { role: k8s_pods, tags: k8s_pods }
 
 - hosts: kubernetes
   remote_user: "{{ container_remote_user }}"


### PR DESCRIPTION
Output is a list of items like:
```
{
    "module": "k8s_pods",
    "source_type": "stockpile",
    "host": "localhost",
    "scribe_uuid": "6f91e6a9-cc77-4e7a-b508-c23b08527247",
    "value": {
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "annotations": {
                "kubernetes.io/config.hash": "abfcb4f52e957b11256c1f6841d49700",
                "kubernetes.io/config.mirror": "abfcb4f52e957b11256c1f6841d49700",
                "kubernetes.io/config.seen": "2019-08-16T16:00:49.402092608Z",
                "kubernetes.io/config.source": "file"
            },
            "creationTimestamp": "2019-08-16T16:02:24Z",
            "labels": {
                "component": "kube-scheduler",
                "tier": "control-plane"
            },
            "name": "kube-scheduler-minikube",
            "namespace": "kube-system",
            "resourceVersion": "3579991",
            "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-minikube",
            "uid": "0d67bf9d-55ed-475d-80f0-9fafc3fae98a"
        },
        "spec": {
            "containers": [
                {
                    "command": [
                        "kube-scheduler",
                        "--bind-address=127.0.0.1",
                        "--kubeconfig=/etc/kubernetes/scheduler.conf",
                        "--leader-elect=true"
                    ],
                    "image": "k8s.gcr.io/kube-scheduler:v1.15.2",
                    "imagePullPolicy": "IfNotPresent",
                    "livenessProbe": {
                        "failureThreshold": 8,
                        "httpGet": {
                            "host": "127.0.0.1",
                            "path": "/healthz",
                            "port": 10251,
                            "scheme": "HTTP"
                        },
                        "initialDelaySeconds": 15,
                        "periodSeconds": 10,
                        "successThreshold": 1,
                        "timeoutSeconds": 15
                    },
                    "name": "kube-scheduler",
                    "resources": {
                        "requests": {
                            "cpu": "100m"
                        }
                    },
                    "terminationMessagePath": "/dev/termination-log",
                    "terminationMessagePolicy": "File",
                    "volumeMounts": [
                        {
                            "mountPath": "/etc/kubernetes/scheduler.conf",
                            "name": "kubeconfig",
                            "readOnly": true
                        }
                    ]
                }
            ],
            "dnsPolicy": "ClusterFirst",
            "enableServiceLinks": true,
            "hostNetwork": true,
            "nodeName": "minikube",
            "priority": 2000000000,
            "priorityClassName": "system-cluster-critical",
            "restartPolicy": "Always",
            "schedulerName": "default-scheduler",
            "securityContext": {},
            "terminationGracePeriodSeconds": 30,
            "tolerations": [
                {
                    "effect": "NoExecute",
                    "operator": "Exists"
                }
            ],
            "volumes": [
                {
                    "hostPath": {
                        "path": "/etc/kubernetes/scheduler.conf",
                        "type": "FileOrCreate"
                    },
                    "name": "kubeconfig"
                }
            ]
        },
        "status": {
            "conditions": [
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:04Z",
                    "status": "True",
                    "type": "Initialized"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:05Z",
                    "status": "True",
                    "type": "Ready"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:05Z",
                    "status": "True",
                    "type": "ContainersReady"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:04Z",
                    "status": "True",
                    "type": "PodScheduled"
                }
            ],
            "containerStatuses": [
                {
                    "containerID": "docker://1d724b769b33a845ae1370964683b969f8bf3a98f47f37559c19bbb19b97b64a",
                    "image": "k8s.gcr.io/kube-scheduler:v1.15.2",
                    "imageID": "docker-pullable://k8s.gcr.io/kube-scheduler@sha256:8fd3c3251f07234a234469e201900e4274726f1fe0d5dc6fb7da911f1c851a1a",
                    "lastState": {
                        "terminated": {
                            "containerID": "docker://23fcc7d561de65b70dbb75097083c3fb83d6fb10bfbbb27905b4c3dccb8f2692",
                            "exitCode": 255,
                            "finishedAt": "2019-09-23T13:47:33Z",
                            "reason": "Error",
                            "startedAt": "2019-09-20T12:33:51Z"
                        }
                    },
                    "name": "kube-scheduler",
                    "ready": true,
                    "restartCount": 67,
                    "state": {
                        "running": {
                            "startedAt": "2019-09-23T13:48:05Z"
                        }
                    }
                }
            ],
            "hostIP": "192.168.124.229",
            "phase": "Running",
            "podIP": "192.168.124.229",
            "qosClass": "Burstable",
            "startTime": "2019-09-23T13:48:04Z"
        }
    }
}
``