### PR TITLE
Add a task dir for the role yum_packages

### DIFF
--- a/roles/yum_packages/tasks/main.yml
+++ b/roles/yum_packages/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Get installed packages (yum)
   yum:
     list: installed
@@ -19,5 +20,3 @@
   set_fact:
     stockpile_dnf_packages: "{{ dnf_installed_packages | json_query('results[*].name') }}"
   when: dnf_installed_packages is not skipped
-
-


### PR DESCRIPTION
The tasks under ``` roles/yum_packages``` were not executed as they have not been defined inside the tasks dir for this role. This PR fixes it.