### PR TITLE
Capture all package information

### DIFF
--- a/roles/yum_packages/tasks/main.yml
+++ b/roles/yum_packages/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: storing the yum packages data
   set_fact:
-    stockpile_yum_packages: "{{ yum_installed_packages | json_query('results[*].name') }}"
+    stockpile_yum_packages: "{{ yum_installed_packages.results }}"
   when: yum_installed_packages is not skipped
 
 - name: Get installed packages (dnf)
@@ -15,8 +15,8 @@
     list: installed
   register: dnf_installed_packages
   when: ansible_pkg_mgr == 'dnf'
-    
+
 - name: storing the dnf packages data
   set_fact:
-    stockpile_dnf_packages: "{{ dnf_installed_packages | json_query('results[*].name') }}"
+    stockpile_dnf_packages: "{{ dnf_installed_packages.results }}"
   when: dnf_installed_packages is not skipped


### PR DESCRIPTION
Stockpile should not just capture the name of installed packages.
It should capture everything.