### PR TITLE
Nvidia smi role

### DIFF
--- a/roles/nvidia_smi/tasks/main.yml
+++ b/roles/nvidia_smi/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: check for nvidia_smi
   stat:
-    path: /usr/bin/nvidia-smi
+    path: '{{ nvidia_smi_path }}nvidia-smi'
   register: nvidia_smi_path
   ignore_errors: yes
 

--- a/roles/nvidia_smi/tasks/main.yml
+++ b/roles/nvidia_smi/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - block:
   - name: capture nvidia_smi info
-    command: nvidia-smi -q -x
+    command: '{{ nvidia_smi_path }} -q -x'
     register: nvidia_smi_info
 
   - name: set the collected nvidia_smi info as facts

--- a/roles/nvidia_smi/tasks/main.yml
+++ b/roles/nvidia_smi/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: check for nvidia_smi
+- name: check for nvidia_smi binary
   stat:
-    path: '{{ nvidia_smi_path }}nvidia-smi'
-  register: nvidia_smi_path
+    path: '{{ nvidia_smi_path }}'
+  register: nvidia_smi_binary
   ignore_errors: yes
 
 
@@ -17,5 +17,5 @@
       stockpile_nvidia_smi:
         xml: "{{ nvidia_smi_info.stdout }}"
         error: "{{ nvidia_smi_info.stderr }}"
-  when: nvidia_smi_path.stat.exists
+  when: nvidia_smi_binary.stat.exists
 

--- a/roles/nvidia_smi/tasks/main.yml
+++ b/roles/nvidia_smi/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: check for nvidia_smi
+  stat:
+    path: /usr/bin/nvidia-smi
+  register: nvidia_smi_path
+  ignore_errors: yes
+
+
+- block:
+  - name: capture nvidia_smi info
+    command: nvidia-smi -q -x
+    register: nvidia_smi_info
+
+  - name: set the collected nvidia_smi info as facts
+    set_fact:
+      stockpile_nvidia_smi:
+        xml: "{{ nvidia_smi_info.stdout }}"
+        error: "{{ nvidia_smi_info.stderr }}"
+  when: nvidia_smi_path.stat.exists
+

--- a/roles/nvidia_smi/vars/main.yml
+++ b/roles/nvidia_smi/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+nvidia_smi_path: '/usr/bin/'
+

--- a/roles/nvidia_smi/vars/main.yml
+++ b/roles/nvidia_smi/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
-nvidia_smi_path: '/usr/bin/'
+nvidia_smi_path: '/usr/bin/nvidia-smi'
 

--- a/stockpile.yml
+++ b/stockpile.yml
@@ -41,6 +41,7 @@
     - { role: k8s_configmaps, become: false, tags: k8s_configmaps }
     - { role: ocp_cluster_config, become: false, tags: ocp_cluster_config }
     - { role: lspci, tags: lspci }
+    - { role: nvidia_smi, tags: nvidia_smi }
 
 - hosts: kubernetes
   remote_user: "{{ container_remote_user }}"


### PR DESCRIPTION
This is a role to integrate the tool "nvidia-smi" into stockpile. This tools collects config info about nvidia GPUs.

Note that when the role is checking if nvidia-smi exists, it is assuming that nvidia-smi exists as "/usr/bin/nvidia-smi" on the host machine. A manually modified path for nvidia-smi which is not "/usr/bin/" will be ignored and this role will not execute.

Edit: Fixed the path problem in a new commit. The user can now set the nvidia_smi_path var to wherever their nvidia-smi binary resides.