### PR TITLE
OCP metadata fixes

### DIFF
--- a/roles/openshift-cluster-topology/tasks/main.yml
+++ b/roles/openshift-cluster-topology/tasks/main.yml
@@ -4,72 +4,31 @@
   register: oc_installed
   ignore_errors: yes
 
-- name: check if kubeconfig exists
-  stat:
-    path: "{{ ansible_env.HOME }}/.kube/config"
-  register: kubeconfig
-
-- name: print debug msg if oc client or kubeconfig doesn't exist
+- name: print debug msg if oc client doesn't exist
   debug:
-    msg: Skipping the ocp collection, cannot find kubeconfig at "{{ ansible_env.HOME }}/.kube/config" or oc client is not installed, please check.
-  when: ( oc_installed.rc != 0 or not kubeconfig.stat.exists )
+    msg: Skipping the ocp collection, oc client is not installed.
+  when: oc_installed.rc != 0
 
 - block:
     - name: get pods in all namespaces
-      command: oc get pods --all-namespaces -o json
+      command: oc get pods --all-namespaces | grep -c Running
       register: ocp_running_pods
 
-    - name: get openshift app node count
-      shell:  oc get nodes -l node-role.kubernetes.io/compute | grep -w "Ready" | wc -l
-      register: ocp_compute_count
+    - name: get openshift worker node count
+      shell:  oc get nodes -l node-role.kubernetes.io/worker= | grep -c Ready
+      register: ocp_worker_count
 
     - name: openshift masters and etcd count assuming that masters are etcd are co-located
-      shell: oc get nodes -l node-role.kubernetes.io/master | grep -w "Ready" | wc -l
+      shell: oc get nodes -l node-role.kubernetes.io/master= | grep -c Ready
       register: ocp_master_count
 
-    - name: ocp cluster network
-      command: oc get clusternetwork -o json
-      register: ocp_network_plugin
-
-    - name: ocp network operator
-      command: oc get networks.operator.openshift.io cluster -o yaml
-      register: ocp_network_operator
-
-    - name: ocp host subnets
-      command: oc get hostsubnet -o json
-      register: ocp_host_subnets
-
-    - name: ocp dns config
-      command: oc get dns -o json
-      register: ocp_dns
-
-    - name: oc client version
-      shell: oc version | awk '/^Client/{print $3}'
-      register: oc_client_version
-
-    - name: oc server version
-      shell: oc version | awk '/^Server/{print $3}'
-      register: oc_server_version
-
-    - name: kubernetes server version
-      shell: oc version | awk '/^Kubernetes/{print $3}'
-      register: kube_server_version
+    - name: oc version
+      shell: oc version -o json
+      register: oc_version
 
     - name: openshift user
       command: oc whoami
       register: ocp_user
-
-    - name: infra pods
-      shell: for infra_node in $(oc get nodes -l node-role.kubernetes.io/infra=true | awk 'NR>1 {print $1}' ); do oc get pods --all-namespaces --field-selector spec.nodeName=$infra_node -o wide | awk 'NR>1 {print $2}'; done
-      register: ocp_infra_pods
-
-    - name: get the system pod names in crashloop state
-      shell: oc get pods -n kube-system -o wide | grep -v "Running" | awk 'NR>1 {print $1}'
-      register: ocp_failed_pods
-
-    - name: get the components status
-      command: oc get cs -o json
-      register: ocp_components_status
 
     - name: services
       command: oc get svc --all-namespaces -o json
@@ -95,48 +54,28 @@
       command: oc get pvc --all-namespaces -o json
       register: ocp_pvc
 
-    - name: openshift compute node config
-      script: openshift_config_scraper.py node-config-compute
-      register: ocp_compute_configmap
+    - name: Get clusterversion
+      command: oc get clusterversion version -o json
+      register: ocp_cluster_version
 
-    - name: openshift master node config
-      script: openshift_config_scraper.py node-config-master
-      register: ocp_master_configmap
-
-    - name: openshift web-console config
-      script: openshift_config_scraper.py webconsole-config
-      register: ocp_webconsole_configmap
-
-    - name: openshift infra node config
-      script: openshift_config_scraper.py node-config-infra
-      register: ocp_infra_configmap
+    - name: Get clusteroperators
+      command: oc get clusterversion co -o json
+      register: ocp_cluster_operators
 
     - name: set the collected info as facts
       set_fact:
         stockpile_openshift_cluster_topology:
-          running_pods_count: "{{ ocp_running_pods.stdout | from_json | json_query('items[].status.phase') | length }}"
-          compute_count: "{{ ocp_compute_count.stdout }}"
+          running_pods_count: "{{ ocp_running_pods.stdout }}"
+          worker_count: "{{ ocp_worker_count.stdout }}"
           master_count: "{{ ocp_master_count.stdout }}"
           etcd_count: "{{ ocp_master_count.stdout }}"
-          cluster_network_plugin: "{{ ocp_network_plugin.stdout | from_json | json_query('items[].pluginName') }}"
-          client_version: "{{ oc_client_version.stdout }}"
-          server_version: "{{ oc_server_version.stdout }}"
+          oc_version: "{{ oc_version }}"
           user: "{{ ocp_user.stdout }}"
-          infra_pods: "{{ ocp_infra_pods.stdout.split('\n') }}"
-          failed_system_pods: "{{ ocp_failed_pods.split('\n') }}"
-          components_status: "{{ ocp_components_status.stdout }}"
           services: "{{ ocp_svc.stdout }}"
           service_accounts: "{{ ocp_sa.stdout }}"
           security_context_constraints: "{{ ocp_scc.stdout }}"
           persistent_volumes: "{{ ocp_pv.stdout }}"
           persistent_volume_claim: "{{ ocp_pvc.stdout }}"
-          kubernetes_server_version: "{{ kube_server_version }}"
-          node_config_compute: "{{ ocp_compute_configmap.stdout }}"
-          node_config_master: "{{ ocp_master_configmap.stdout }}"
-          node_config_infra: "{{ ocp_infra_configmap.stdout }}"
-          web_console_config: "{{ ocp_webconsole_configmap.stdout }}"
-          storage_classes: "{{ ocp_sc }}"
-          network_operator: "{{ ocp_network_operator }}"
-          dns: "{{ ocp_dns }}"
-          host_subnets: "{{ ocp_host_subnets }}"
-  when: ( oc_installed.rc == 0 and kubeconfig.stat.exists )
+          storage_classes: "{{ ocp_sc.stdout }}"
+          ocp_cluster_operators: "{{ ocp_cluster_operators.stdout }}"
+  when: oc_installed.rc == 0

--- a/roles/openshift-networking/tasks/main.yml
+++ b/roles/openshift-networking/tasks/main.yml
@@ -5,11 +5,6 @@
   register: oc_installed
   ignore_errors: yes
 
-- name: Check if kubeconfig exists
-  stat:
-    path: "{{ ansible_env.HOME }}/.kube/config"
-  register: kubeconfig
-
 - block:
   - name: Get ocp network operator
     command: oc get networks.operator.openshift.io cluster -o json
@@ -26,16 +21,13 @@
   - name: Set network operator
     set_fact:
       stockpile_ocp_network_operator: "{{ ocp_network_operator.stdout }}"
-    when: ocp_network_operator.rc == 0
 
   - name: Set dns config
     set_fact:
       stockpile_ocp_dns: "{{ ocp_dns.stdout }}"
-    when: ocp_dns.rc == 0
 
   - name: Set network attachment deffinitions
     set_fact:
       stockpile_ocp_net_attachments: "{{ ocp_net_attachments.stdout | from_json | json_query('items') }}"
-    when: ocp_net_attachments.rc == 0
 
-  when: ( oc_installed.rc == 0 and kubeconfig.stat.exists )
+  when: oc_installed.rc == 0

--- a/roles/openshift-nodes/tasks/main.yml
+++ b/roles/openshift-nodes/tasks/main.yml
@@ -1,96 +1,24 @@
 ---
-- name: check if the docker is installed
-  command: which docker
-  register: docker_installed
-  ignore_errors: yes
-
-- block:
-   - name: ensure that docker is running
-     service:
-       name: docker
-       state: started
-
-   - name: docker status
-     command: systemctl status docker
-     register: docker_status
-
-   - debug:
-       msg: "{{ docker_status.stdout }}"
-     when: docker_status.rc != 0
-  when: docker_installed.rc == 0
-
-- block:
-    - name: get the docker version
-      shell: docker --version | cut -d "," -f1 | cut -d ' ' -f3
-      register: docker_version_installed
-
-    - name: get the docker storage driver info
-      shell: docker info | grep -w "Storage Driver" | cut -d ':' -f2
-      register: docker_storage_driver_info
-  when: ( docker_installed.rc == 0 and docker_status.rc == 0 )
-
 - name: check if oc client is installed
   command: which oc
   register: oc_installed
   ignore_errors: yes
 
-- name: check if kubeconfig exists
-  stat:
-    path: "{{ ansible_env.HOME }}/.kube/config"
-  register: kubeconfig
-
-- name: print debug message if oc client or kubeconfig doesn't exist
+- name: print debug message if oc client doesn't exist
   debug:
-    msg: Skipping the ocp collection, cannot find kubeconfig at "{{ ansible_env.HOME }}/.kube/config" or oc client is not installed, please check.
-  when: ( oc_installed.rc != 0 or not kubeconfig.stat.exists )
+    msg: Skipping the ocp collection, oc client is not installed, please check.
+  when: oc_installed.rc != 0
 
 - block:
-    - name: determine virtualization technology
-      command: dmidecode -s system-product-name
-      register: virtualization_info
-
-    - name: get atomic openshift tests rpm version
-      shell: rpm -q --qf "%{VERSION}" atomic-openshift-tests
-      register: ocp_tests_version
-
-    - name: get atomic openshift pod version
-      shell: rpm -q --qf "%{VERSION}" atomic-openshift-pod
-      register: ocp_pod_version
-
-    - name: get atomic openshift node version
-      shell: rpm -q --qf "%{VERSION}" atomic-openshift-node
-      register: ocp_node_version
-
-    - name: get atomic openshift docker registry version
-      shell: rpm -q --qf "%{VERSION}" atomic-openshift-dockerregistry
-      register: ocp_dockerregistry_version
-
-    - name: get tuned profiles version
-      shell: rpm -q --qf "%{VERSION}" tuned-profiles-atomic
-      register: tuned_profiles_atomic
-
-    - name: kernel version
-      command: uname -r
-      register: kernel_info
 
     - name: get node info
-      shell: oc get node $(hostname) -o json
+      shell: oc get node ${my_node_name} -o json
       register: ocp_node_info
 
     - name: set collected info as facts
       set_fact:
         stockpile_openshift_node:
-          virtualization: "{{ virtualization_info.stdout }}"
-          docker_version: "{{ docker_version_installed.stdout }}"
-          docker_storage_driver: "{{ docker_storage_driver_info.stdout }}"
-          tests_version: "{{ ocp_tests_version.stdout }}"
-          pod_version: "{{ ocp_pod_version.stdout }}"
-          node_version: "{{ ocp_node_version.stdout }}"
-          dockerregistry_version: "{{ ocp_dockerregistry_version.stdout }}"
-          tuned_profiles_version: "{{ tuned_profiles_atomic.stdout }}"
-          kernel_version: "{{ kernel_info.stdout }}"
           capacity: "{{ ocp_node_info.stdout | from_json | json_query('status.capacity') }}"
           allocatable: "{{ ocp_node_info.stdout | from_json | json_query('status.allocatable') }}"
           node_info: "{{ ocp_node_info.stdout | from_json | json_query('status.nodeInfo') }}"
-          daemon_endpoints: "{{ ocp_node_info.stdout | from_json | json_query('status.daemonEndpoints') }}"
-  when: ( oc_installed.rc == 0 or kubeconfig.stat.exists )
+  when: oc_installed.rc == 0


### PR DESCRIPTION
Most of metadata collected is outdated with OpenShift4.
In addition, kubeconfig does not exist when running stockpile from backpack. so this metadata is never collected.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>