### PR TITLE
remove traling 0 from the major version

### DIFF
--- a/roles/openstack_version/tasks/main.yml
+++ b/roles/openstack_version/tasks/main.yml
@@ -22,6 +22,10 @@
   set_fact:
     rhosp_major: "{{ rhosp_version | regex_replace('([0-9]+\\.[0-9]+).*', '\\1') }}"
 
+- name: remove trailing .0 from the major version
+  set_fact:
+    rhosp_major: "{{ rhosp_major | regex_replace('([0-9]+)\\.[0]', '\\1') }}"
+
 - name: check if repos exist
   stat:
     path: /etc/yum.repos.d/rhos-release-{{rhosp_major}}.repo


### PR DESCRIPTION
if the major version is 16.0 then it is not able to find the rhos-release-16.0.repo
so removing the trailing zero from the major version