### PR TITLE
Drop trailing 0 only for 16.0

### DIFF
--- a/roles/openstack_version/tasks/main.yml
+++ b/roles/openstack_version/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: set rhosp major version
   set_fact:
     rhosp_major: "{{ rhosp_version | regex_replace('([0-9]+\\.[0-9]+).*', '\\1') }}"
+  when: rhosp_version is version('16.0', '<=')
 
 - name: check if repos exist
   stat:

--- a/roles/openstack_version/tasks/main.yml
+++ b/roles/openstack_version/tasks/main.yml
@@ -22,10 +22,6 @@
   set_fact:
     rhosp_major: "{{ rhosp_version | regex_replace('([0-9]+\\.[0-9]+).*', '\\1') }}"
 
-- name: remove trailing .0 from the major version
-  set_fact:
-    rhosp_major: "{{ rhosp_major | regex_replace('([0-9]+)\\.[0]', '\\1') }}"
-
 - name: check if repos exist
   stat:
     path: /etc/yum.repos.d/rhos-release-{{rhosp_major}}.repo


### PR DESCRIPTION
The file for 17.0 is /etc/yum.repos.d/rhos-release-17.0.repo, and due to removal of trailing zero it looks for
/etc/yum.repos.d/rhos-release-17.repo and fails to find puddle info.
so reverting the task to trim the trailing 0 from
rhosp_major.

Fixes: #117
This reverts commit 04260cf9c6c15eb83eb2d9978f4182dce2cc7a55.

### Description

### Fixes
