### PR TITLE
Readd remove trailing .0 task

### DIFF
--- a/roles/openstack_version/tasks/main.yml
+++ b/roles/openstack_version/tasks/main.yml
@@ -21,6 +21,10 @@
 - name: set rhosp major version
   set_fact:
     rhosp_major: "{{ rhosp_version | regex_replace('([0-9]+\\.[0-9]+).*', '\\1') }}"
+
+- name: remove trailing .0 from the major version
+  set_fact:
+    rhosp_major: "{{ rhosp_major | regex_replace('([0-9]+)\\.[0]', '\\1') }}"
   when: rhosp_version is version('16.0', '<=')
 
 - name: check if repos exist


### PR DESCRIPTION
It was accidentally removed in previous commit, readding it.

### Description

### Fixes
